### PR TITLE
titles for specs

### DIFF
--- a/lib/action_policy/rspec/dsl.rb
+++ b/lib/action_policy/rspec/dsl.rb
@@ -68,7 +68,7 @@ if defined?(::RSpec)
 
   ::RSpec.shared_examples_for "action_policy:policy_rule_example" do |success, the_caller|
     if success
-      specify do
+      specify 'is allowed' do
         next if subject.success?
         raise(
           RSpec::Expectations::ExpectationNotMetError,
@@ -77,7 +77,7 @@ if defined?(::RSpec)
         )
       end
     else
-      specify do
+      specify 'is disallowed' do
         next if subject.fail?
         raise(
           RSpec::Expectations::ExpectationNotMetError,


### PR DESCRIPTION
### What is the purpose of this pull request?

Specify titles for tests, so that running rspec with `--format documentation` returns meaningful details like:

```
ProjectPolicy
  index?
    when not authenticated
      is disallowed
    when user is reader
      is allowed
```

### What changes did you make? (overview)

Added titles to rspec `specify`

### Is there anything you'd like reviewers to focus on?

Titles make sense? Better ideas?

PR checklist:

- [ ] Tests included
- [ ] Documentation updated
- [ ] Changelog entry added
